### PR TITLE
Fix error message.

### DIFF
--- a/src/rdf_storage.c
+++ b/src/rdf_storage.c
@@ -522,7 +522,7 @@ librdf_new_storage(librdf_world *world,
   if(!factory) {
     librdf_log(world, 
                0, LIBRDF_LOG_ERROR, LIBRDF_FROM_STORAGE, NULL,
-               "storage '%s' not found", name);
+               "storage '%s' not found", storage_name);
     return NULL;
   }
 


### PR DESCRIPTION
In `librdf_new_storage_with_options` the variable `name` was being
used in an error message instead of `storage_name`.

I am not too familiar with this library / code base, but I believe that the error message I changed in this PR is incorrect.  As you can see, the `name` variable is not even used prior to this error message.
