### PR TITLE
When the parser provides quads and contexts are enabled...

### DIFF
--- a/src/rdf_parser_raptor.c
+++ b/src/rdf_parser_raptor.c
@@ -266,8 +266,19 @@ librdf_parser_raptor_new_statement_handler(void *context,
 #endif
 
   if(scontext->model) {
-    rc=librdf_model_add_statement(scontext->model, statement);
-    librdf_free_statement(statement);
+	if(librdf_model_supports_contexts(scontext->model) &&
+	   rstatement->graph &&
+	   rstatement->graph->type == RAPTOR_TERM_TYPE_URI)
+	{
+	  node = librdf_new_node_from_uri(world, (librdf_uri*)rstatement->graph->value.uri);
+	  rc = librdf_model_context_add_statement(scontext->model, node, statement);
+	  librdf_free_node(node);
+	}
+	else
+	{
+	  rc=librdf_model_add_statement(scontext->model, statement);
+	}
+	librdf_free_statement(statement);
   } else {
     rc=librdf_list_add(scontext->statements, statement);
     if(rc)


### PR DESCRIPTION
...in a model being parsed into, convert graph URIs from Raptor into contexts in the model.
