### PR TITLE
Load virtuoso query engine (vsparql) in modular builds as well

### DIFF
--- a/src/rdf_storage_virtuoso.c
+++ b/src/rdf_storage_virtuoso.c
@@ -3102,6 +3102,9 @@ librdf_storage_module_register_factory(librdf_world *world)
   librdf_storage_register_factory(world, "virtuoso",
                                   "OpenLink Virtuoso Universal Server store",
                                   &librdf_storage_virtuoso_register_factory);
+  /* also register the virtuoso query engine seeing
+   * as rdf_query_virtuoso is linked into this module/DSO */
+  librdf_init_query_virtuoso(world);
 }
 
 #else
@@ -3118,6 +3121,8 @@ librdf_init_storage_virtuoso(librdf_world *world)
   librdf_storage_register_factory(world, "virtuoso",
                                   "OpenLink Virtuoso Universal Server store",
                                   &librdf_storage_virtuoso_register_factory);
+  /* in the monolithic case virtuoso's query engine is
+   * registered separately in librdf_init_query() */
 }
 
 #endif


### PR DESCRIPTION
This changeset completes 942bba27.  The virtuoso query engine (vsparql)
in a monolithic build is registered upon the STORAGE_VIRTUOSO condition
in librdf_init_query() whilst there was no equivalent procedure in the
modular case.

In this changeset, we hook into virtuoso's ltdl entry point routine
librdf_storage_module_register_factory() and register vsparql there
and then.  This will work as long as there's no additional initialiser
code in librdf_init_query() (which there isn't at the moment).
