### PR TITLE
Fix build with mysql-connector-c v8.0.18

### DIFF
--- a/src/rdf_storage_mysql.c
+++ b/src/rdf_storage_mysql.c
@@ -447,7 +447,7 @@ librdf_storage_mysql_get_handle(librdf_storage* storage)
 
 #ifdef HAVE_MYSQL_OPT_RECONNECT
   if(1) {
-    my_bool value=(context->reconnect) ? 1 : 0;
+    bool value=(context->reconnect) ? 1 : 0;
     mysql_options(connection->handle, MYSQL_OPT_RECONNECT, &value);
   }
 #endif


### PR DESCRIPTION
This fixes following compilation failure with version 8.0.18 of
mysql-connector-c:
```
rdf_storage_mysql.c: In function 'librdf_storage_mysql_get_handle':
rdf_storage_mysql.c:450:5: error: unknown type name 'my_bool'; did you mean 'bool'?
  450 |     my_bool value=(context->reconnect) ? 1 : 0;
      |     ^~~~~~~
      |     bool
make[3]: *** [Makefile:886: librdf_storage_mysql_la-rdf_storage_mysql.lo] Error 1
```

The correct type for calling `mysql_options` with `MYSQL_OPT_RECONNECT`
in version 8.0 of the library is `bool*`:
https://dev.mysql.com/doc/refman/8.0/en/mysql-options.html

See-Also: https://bugs.gentoo.org/692462